### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/edgenode/internal/nts/Dockerfile
+++ b/edgenode/internal/nts/Dockerfile
@@ -6,8 +6,8 @@ FROM centos:7.6.1810 AS nts-deps-image
 RUN yum upgrade -y ca-certificates && \
     yum install -y epel-release && \
     yum install -y numactl-devel libhugetlbfs-utils iproute python3 python3-pip sudo && \
-    pip3 install docker==4.2.1 && \
-    pip3 install configparser==5.0.0
+    pip3 install --no-cache-dir docker==4.2.1 && \
+    pip3 install --no-cache-dir configparser==5.0.0
 
 FROM nts-deps-image
 

--- a/oek/roles/openness/dataplane/ovncni/common/templates/Dockerfile.j2
+++ b/oek/roles/openness/dataplane/ovncni/common/templates/Dockerfile.j2
@@ -26,7 +26,7 @@ RUN yum install -y \
   && \
   yum install -y python-pip openssl11
 
-RUN pip install six
+RUN pip install --no-cache-dir six
 
 COPY lib $DPDK_DIR/lib
 COPY drivers $DPDK_DIR/drivers


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik raj <rajpratik71@gmail.com>